### PR TITLE
Clarify semantics of publish confirms

### DIFF
--- a/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java
+++ b/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java
@@ -50,8 +50,10 @@ public class SampleSender {
             .thenMany(confirmations)
                 .doOnError(e -> LOGGER.error("Send failed", e))
                 .subscribe(r -> {
-                    LOGGER.info("Message {} sent successfully", new String(r.getOutboundMessage().getBody()));
-                    latch.countDown();
+                    if (r.isAck()) {
+                        LOGGER.info("Message {} sent successfully", new String(r.getOutboundMessage().getBody()));
+                        latch.countDown();
+                    }
                 });
     }
 


### PR DESCRIPTION
This PR is rather a question regarding the semantics of publish confirms and the resulting `Flux<OutboundMessageResult>`.

Looking at the code it looks more that I should look at r.isAck() to tell if the message is confirmed by the broker.
So is it true that the `Flux<OutboundMessageResult>` contains an entry for every outbound message regardless if confirmed or not.
Or does it only contain an element for every successful delivery?