### PR TITLE
DO NET MERGE YET Bump Java client to 5.5.1 for topology recovery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
 	logbackVersion = '1.2.3'
 
 	// Libraries
-	rabbitMqJavaClientVersion = '5.5.0'
+	rabbitMqJavaClientVersion = '5.5.1-SNAPSHOT'
 
 	// Testing
 	mockitoVersion = '1.10.19'
@@ -75,6 +75,7 @@ configure(allprojects) { project ->
 	repositories {
 		maven { url 'http://repo.spring.io/libs-release' }
 		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 		mavenCentral()
 		jcenter()
 	}


### PR DESCRIPTION
Topology isn't recorded in RPC methods, this is fixed in Java client 5.5.1. Added a test to check.

Fixes #37