### PR TITLE
Channel mono

### DIFF
--- a/src/main/java/reactor/rabbitmq/ChannelCloseHandlers.java
+++ b/src/main/java/reactor/rabbitmq/ChannelCloseHandlers.java
@@ -16,7 +16,7 @@ public class ChannelCloseHandlers {
         @Override
         public void accept(SignalType signalType, Channel channel) {
             int channelNumber = channel.getChannelNumber();
-            LOGGER.info("closing channel {} by signal {}", channelNumber, signalType);
+            LOGGER.debug("closing channel {} by signal {}", channelNumber, signalType);
             try {
                 if (channel.isOpen() && channel.getConnection().isOpen()) {
                     channel.close();

--- a/src/main/java/reactor/rabbitmq/ChannelCloseHandlers.java
+++ b/src/main/java/reactor/rabbitmq/ChannelCloseHandlers.java
@@ -1,0 +1,30 @@
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.SignalType;
+
+import java.util.function.BiConsumer;
+
+public class ChannelCloseHandlers {
+
+    public static class SenderChannelCloseHandler implements BiConsumer<SignalType, Channel> {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(SenderChannelCloseHandler.class);
+
+        @Override
+        public void accept(SignalType signalType, Channel channel) {
+            int channelNumber = channel.getChannelNumber();
+            LOGGER.info("closing channel {} by signal {}", channelNumber, signalType);
+            try {
+                if (channel.isOpen() && channel.getConnection().isOpen()) {
+                    channel.close();
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Channel {} didn't close normally: {}", channelNumber, e.getMessage());
+            }
+        }
+    }
+
+}

--- a/src/main/java/reactor/rabbitmq/SendOptions.java
+++ b/src/main/java/reactor/rabbitmq/SendOptions.java
@@ -16,6 +16,10 @@
 
 package reactor.rabbitmq;
 
+import com.rabbitmq.client.Channel;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+
 import java.time.Duration;
 import java.util.function.BiConsumer;
 
@@ -28,12 +32,34 @@ public class SendOptions {
         Duration.ofSeconds(10), Duration.ofMillis(200), ExceptionHandlers.CONNECTION_RECOVERY_PREDICATE
     );
 
+    private Mono<? extends Channel> channelMono;
+
+    private BiConsumer<SignalType, Channel> channelCloseHandler;
+
     public BiConsumer<Sender.SendContext, Exception> getExceptionHandler() {
         return exceptionHandler;
     }
 
     public SendOptions exceptionHandler(BiConsumer<Sender.SendContext, Exception> exceptionHandler) {
         this.exceptionHandler = exceptionHandler;
+        return this;
+    }
+
+    public Mono<? extends Channel> getChannelMono() {
+        return channelMono;
+    }
+
+    public SendOptions channelMono(Mono<? extends Channel> channelMono) {
+        this.channelMono = channelMono;
+        return this;
+    }
+
+    public BiConsumer<SignalType, Channel> getChannelCloseHandler() {
+        return channelCloseHandler;
+    }
+
+    public SendOptions channelCloseHandler(BiConsumer<SignalType, Channel> channelCloseHandler) {
+        this.channelCloseHandler = channelCloseHandler;
         return this;
     }
 }

--- a/src/main/java/reactor/rabbitmq/SendOptions.java
+++ b/src/main/java/reactor/rabbitmq/SendOptions.java
@@ -16,10 +16,6 @@
 
 package reactor.rabbitmq;
 
-import com.rabbitmq.client.Channel;
-import reactor.core.publisher.Mono;
-import reactor.core.publisher.SignalType;
-
 import java.time.Duration;
 import java.util.function.BiConsumer;
 
@@ -32,10 +28,6 @@ public class SendOptions {
         Duration.ofSeconds(10), Duration.ofMillis(200), ExceptionHandlers.CONNECTION_RECOVERY_PREDICATE
     );
 
-    private Mono<? extends Channel> channelMono;
-
-    private BiConsumer<SignalType, Channel> channelCloseHandler;
-
     public BiConsumer<Sender.SendContext, Exception> getExceptionHandler() {
         return exceptionHandler;
     }
@@ -45,21 +37,4 @@ public class SendOptions {
         return this;
     }
 
-    public Mono<? extends Channel> getChannelMono() {
-        return channelMono;
-    }
-
-    public SendOptions channelMono(Mono<? extends Channel> channelMono) {
-        this.channelMono = channelMono;
-        return this;
-    }
-
-    public BiConsumer<SignalType, Channel> getChannelCloseHandler() {
-        return channelCloseHandler;
-    }
-
-    public SendOptions channelCloseHandler(BiConsumer<SignalType, Channel> channelCloseHandler) {
-        this.channelCloseHandler = channelCloseHandler;
-        return this;
-    }
 }

--- a/src/main/java/reactor/rabbitmq/SenderOptions.java
+++ b/src/main/java/reactor/rabbitmq/SenderOptions.java
@@ -20,8 +20,10 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Scheduler;
 
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 /**
@@ -36,6 +38,10 @@ public class SenderOptions {
     }).get();
 
     private Mono<? extends Connection> connectionMono;
+
+    private Mono<? extends Channel> channelMono;
+
+    private BiConsumer<SignalType, Channel> channelCloseHandler;
 
     private Scheduler resourceManagementScheduler;
 
@@ -98,6 +104,24 @@ public class SenderOptions {
 
     public Mono<? extends Connection> getConnectionMono() {
         return connectionMono;
+    }
+
+    public SenderOptions channelMono(Mono<? extends Channel> channelMono) {
+        this.channelMono = channelMono;
+        return this;
+    }
+
+    public Mono<? extends Channel> getChannelMono() {
+        return channelMono;
+    }
+
+    public BiConsumer<SignalType, Channel> getChannelCloseHandler() {
+        return channelCloseHandler;
+    }
+
+    public SenderOptions channelCloseHandler(BiConsumer<SignalType, Channel> channelCloseHandler) {
+        this.channelCloseHandler = channelCloseHandler;
+        return this;
     }
 
     public SenderOptions resourceManagementChannelMono(Mono<? extends Channel> resourceManagementChannelMono) {

--- a/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
+++ b/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
@@ -550,26 +550,6 @@ public class RabbitFluxTests {
     }
 
     @Test
-    public void senderWithCustomChannelCloseHandlerPriority() throws Exception {
-        int nbMessages = 10;
-        Flux<OutboundMessage> msgFlux = Flux.range(0, nbMessages).map(i -> new OutboundMessage("", queue, "".getBytes()));
-
-        SenderChannelCloseHandler channelCloseHandlerInSenderOptions = mock(SenderChannelCloseHandler.class);
-        SenderChannelCloseHandler channelCloseHandlerInSendOptions = mock(SenderChannelCloseHandler.class);
-
-        SenderOptions senderOptions = new SenderOptions().channelCloseHandler(channelCloseHandlerInSenderOptions);
-        sender = createSender(senderOptions);
-        SendOptions sendOptions = new SendOptions().channelCloseHandler(channelCloseHandlerInSendOptions);
-
-        StepVerifier.create(sender.send(msgFlux, sendOptions))
-                .verifyComplete();
-
-        verify(channelCloseHandlerInSenderOptions, never()).accept(any(SignalType.class), any(Channel.class));
-        verify(channelCloseHandlerInSendOptions, times(1)).accept(any(SignalType.class), any(Channel.class));
-
-    }
-
-    @Test
     public void publishConfirms() throws Exception {
         int nbMessages = 10;
         CountDownLatch consumedLatch = new CountDownLatch(nbMessages);


### PR DESCRIPTION
This PR has been triggered by [issue#41](https://github.com/reactor/reactor-rabbitmq/issues/41)

There have been added following properties to ~~both~~ SenderOptions ~~and SendOptions~~:

- `Mono<? extends Channel> channelMono`

- `BiConsumer<SignalType, Channel> channelCloseHandler`

There is another subtle change referring to discrepancy of caching channel creation 

- `Sender#send` uses `connectionMono.map(CHANNEL_CREATION_FUNCTION).cache()`
- `Sender#sendWithPublishConfirms` uses `connectionMono.map(CHANNEL_CREATION_FUNCTION)`

I removed cache() in `Sender#send` 