### PR TITLE
Sender channel pool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
 }
 plugins {
 	id 'org.asciidoctor.convert' version '1.5.6'
+	id 'me.champeau.gradle.jmh' version '0.4.7'
 }
 
 ext {

--- a/src/jmh/java/reactor/rabbitmq/SenderBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderBenchmark.java
@@ -1,0 +1,61 @@
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.Connection;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(2)
+public class SenderBenchmark {
+
+    Connection connection;
+    Sender sender;
+    String queue;
+    Flux<OutboundMessage> msgFlux;
+
+    @Param({"1", "10", "100", "1000"})
+    public int nbMessages;
+
+    @Setup
+    public void setupConnection() throws Exception {
+        connection = SenderBenchmarkUtils.newConnection();
+    }
+
+    @TearDown
+    public void closeConnection() throws Exception {
+        connection.close();
+    }
+
+    @Setup(Level.Iteration)
+    public void setupSender() throws Exception {
+        queue = SenderBenchmarkUtils.declareQueue(connection);
+        sender = RabbitFlux.createSender();
+        msgFlux = SenderBenchmarkUtils.outboundMessageFlux(queue, nbMessages);
+    }
+
+    @TearDown(Level.Iteration)
+    public void tearDownSender() throws Exception {
+        SenderBenchmarkUtils.deleteQueue(connection, queue);
+        if (sender != null) {
+            sender.close();
+        }
+    }
+
+    @Benchmark
+    public void send(Blackhole blackhole) {
+        blackhole.consume(sender.send(msgFlux).block());
+    }
+
+    @Benchmark
+    public void sendWithPublishConfirms(Blackhole blackhole) {
+        blackhole.consume(sender.sendWithPublishConfirms(msgFlux).blockLast());
+    }
+}

--- a/src/jmh/java/reactor/rabbitmq/SenderBenchmarkUtils.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderBenchmarkUtils.java
@@ -1,0 +1,36 @@
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import reactor.core.publisher.Flux;
+
+import java.util.UUID;
+
+public class SenderBenchmarkUtils {
+
+    public static Flux<OutboundMessage> outboundMessageFlux(String queue, int nbMessages) {
+        return Flux.range(0, nbMessages).map(i -> new OutboundMessage("", queue, "".getBytes()));
+    }
+
+    public static Connection newConnection() throws Exception {
+        ConnectionFactory connectionFactory = new ConnectionFactory();
+        connectionFactory.useNio();
+        return connectionFactory.newConnection();
+    }
+
+    public static String declareQueue(Connection connection) throws Exception {
+        String queueName = UUID.randomUUID().toString();
+        Channel channel = connection.createChannel();
+        String queue = channel.queueDeclare(queueName, false, false, false, null).getQueue();
+        channel.close();
+        return queue;
+    }
+
+    public static void deleteQueue(Connection connection, String queue) throws Exception {
+        Channel channel = connection.createChannel();
+        channel.queueDelete(queue);
+        channel.close();
+    }
+
+}

--- a/src/jmh/java/reactor/rabbitmq/SenderWithLazyChannelPoolBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderWithLazyChannelPoolBenchmark.java
@@ -1,0 +1,69 @@
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.Connection;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(2)
+public class SenderWithLazyChannelPoolBenchmark {
+
+    Connection connection;
+    ChannelPool channelPool;
+    Sender sender;
+    String queue;
+    Flux<OutboundMessage> msgFlux;
+
+    @Param({"1", "10", "25"})
+    public int channelPoolSize;
+
+    @Param({"1", "10", "100", "1000"})
+    public int nbMessages;
+
+    @Setup
+    public void setupConnection() throws Exception {
+        connection = SenderBenchmarkUtils.newConnection();
+        channelPool = ChannelPoolFactory.createChannelPool(Mono.just(connection), new ChannelPoolOptions().maxCacheSize(channelPoolSize));
+    }
+
+    @TearDown
+    public void closeConnection() throws Exception {
+        connection.close();
+        channelPool.close();
+    }
+
+    @Setup(Level.Iteration)
+    public void setupSender() throws Exception {
+        queue = SenderBenchmarkUtils.declareQueue(connection);
+        sender = RabbitFlux.createSender();
+        msgFlux = SenderBenchmarkUtils.outboundMessageFlux(queue, nbMessages);
+    }
+
+    @TearDown(Level.Iteration)
+    public void tearDownSender() throws Exception {
+        SenderBenchmarkUtils.deleteQueue(connection, queue);
+        if (sender != null) {
+            sender.close();
+        }
+    }
+
+//    @Benchmark
+    public void send(Blackhole blackhole) {
+        blackhole.consume(sender.send(msgFlux, new SendOptions().channelPool(channelPool)).block());
+    }
+
+//    @Benchmark
+    public void sendWithPublishConfirms(Blackhole blackhole) {
+        blackhole.consume(sender.sendWithPublishConfirms(msgFlux, new SendOptions().channelPool(channelPool)).blockLast());
+    }
+
+}

--- a/src/jmh/java/reactor/rabbitmq/SenderWithLazyChannelPoolBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderWithLazyChannelPoolBenchmark.java
@@ -56,12 +56,12 @@ public class SenderWithLazyChannelPoolBenchmark {
         }
     }
 
-//    @Benchmark
+    @Benchmark
     public void send(Blackhole blackhole) {
         blackhole.consume(sender.send(msgFlux, new SendOptions().channelPool(channelPool)).block());
     }
 
-//    @Benchmark
+    @Benchmark
     public void sendWithPublishConfirms(Blackhole blackhole) {
         blackhole.consume(sender.sendWithPublishConfirms(msgFlux, new SendOptions().channelPool(channelPool)).blockLast());
     }

--- a/src/main/java/reactor/rabbitmq/ChannelPool.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPool.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+
+import java.util.function.BiConsumer;
+
+public interface ChannelPool {
+
+    Mono<? extends Channel> getChannelMono();
+
+    BiConsumer<SignalType, Channel> getChannelCloseHandler();
+
+    void close();
+
+}

--- a/src/main/java/reactor/rabbitmq/ChannelPoolFactory.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPoolFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.Connection;
+import reactor.core.publisher.Mono;
+
+public class ChannelPoolFactory {
+
+    public static ChannelPool createChannelPool(Mono<? extends Connection> connectionMono) {
+        return createChannelPool(connectionMono, new ChannelPoolOptions());
+    }
+
+    public static ChannelPool createChannelPool(Mono<? extends Connection> connectionMono, ChannelPoolOptions channelPoolOptions) {
+        return new LazyChannelPool(connectionMono, channelPoolOptions);
+    }
+
+}

--- a/src/main/java/reactor/rabbitmq/ChannelPoolOptions.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPoolOptions.java
@@ -17,21 +17,20 @@
 package reactor.rabbitmq;
 
 import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 
 public class ChannelPoolOptions {
 
-    private int maxSize = 5;
+    private Integer maxCacheSize;
 
-    private Scheduler subscriptionScheduler = Schedulers.newElastic("sender-channel-pool");
+    private Scheduler subscriptionScheduler;
 
-    public ChannelPoolOptions maxSize(int maxSize) {
-        this.maxSize = maxSize;
+    public ChannelPoolOptions maxCacheSize(int maxCacheSize) {
+        this.maxCacheSize = maxCacheSize;
         return this;
     }
 
-    public int getMaxSize() {
-        return maxSize;
+    public Integer getMaxCacheSize() {
+        return maxCacheSize;
     }
 
     public ChannelPoolOptions subscriptionScheduler(Scheduler subscriptionScheduler) {

--- a/src/main/java/reactor/rabbitmq/ChannelPoolOptions.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPoolOptions.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.rabbitmq;
+
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+public class ChannelPoolOptions {
+
+    private int maxSize = 5;
+
+    private Scheduler subscriptionScheduler = Schedulers.newElastic("sender-channel-pool");
+
+    public ChannelPoolOptions maxSize(int maxSize) {
+        this.maxSize = maxSize;
+        return this;
+    }
+
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    public ChannelPoolOptions subscriptionScheduler(Scheduler subscriptionScheduler) {
+        this.subscriptionScheduler = subscriptionScheduler;
+        return this;
+    }
+
+    public Scheduler getSubscriptionScheduler() {
+        return subscriptionScheduler;
+    }
+}

--- a/src/main/java/reactor/rabbitmq/LazyChannelPool.java
+++ b/src/main/java/reactor/rabbitmq/LazyChannelPool.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+import reactor.core.scheduler.Scheduler;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.BiConsumer;
+
+import static reactor.rabbitmq.ChannelCloseHandlers.SENDER_CHANNEL_CLOSE_HANDLER_INSTANCE;
+
+/**
+ * This channel pool is lazy initialized. It might even not reach its maximum size {@link ChannelPoolOptions#getMaxSize()} in low-traffic environments.
+ * It always tries to obtain channel from the pool. However, in case of high-traffic number of channels might exceeds channel pool maximum size.
+ *
+ * Channels are added to the pool after their use {@link ChannelPool#getChannelCloseHandler()} and obtained from the pool when channel is requested {@link ChannelPool#getChannelMono()}.
+ *
+ * If pool is empty, new channel is created.
+ * If channel is no longer needed and the channel pool is full (high-traffic), then channel is being closed.
+ * If channel is no longer needed and the channel pool has not reached its capacity, then channel is added to the pool.
+ *
+ * It uses {@link BlockingQueue} internally in a non-blocking way.
+ *
+ */
+class LazyChannelPool implements ChannelPool {
+
+    private final Mono<? extends Connection> connectionMono;
+    private final BlockingQueue<Channel> channelsQueue;
+    private final Scheduler subscriptionScheduler;
+
+    LazyChannelPool(Mono<? extends Connection> connectionMono, ChannelPoolOptions channelPoolOptions) {
+        this.channelsQueue = new LinkedBlockingQueue<>(channelPoolOptions.getMaxSize());
+        this.connectionMono = connectionMono;
+        this.subscriptionScheduler = channelPoolOptions.getSubscriptionScheduler();
+    }
+
+    public Mono<? extends Channel> getChannelMono() {
+        return connectionMono.map(connection -> {
+            Channel channel = channelsQueue.poll();
+            if (channel == null) {
+                channel = createChannel(connection);
+            }
+            return channel;
+        }).subscribeOn(subscriptionScheduler);
+    }
+
+    @Override
+    public BiConsumer<SignalType, Channel> getChannelCloseHandler() {
+        return (signalType, channel) -> {
+            if (!channel.isOpen()) {
+                return;
+            }
+            // maybe also close channel if signalType == SignalType.ON_ERROR ?
+            boolean offer = channelsQueue.offer(channel);
+            if (!offer) {
+                SENDER_CHANNEL_CLOSE_HANDLER_INSTANCE.accept(signalType, channel);
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+        List<Channel> channels = new ArrayList<>();
+        channelsQueue.drainTo(channels);
+        channels.forEach(channel -> {
+            SENDER_CHANNEL_CLOSE_HANDLER_INSTANCE.accept(SignalType.ON_COMPLETE, channel);
+        });
+    }
+
+    private Channel createChannel(Connection connection) {
+        try {
+            return connection.createChannel();
+        } catch (IOException e) {
+            throw new RabbitFluxException("Error while creating channel", e);
+        }
+    }
+
+}

--- a/src/main/java/reactor/rabbitmq/SendOptions.java
+++ b/src/main/java/reactor/rabbitmq/SendOptions.java
@@ -98,4 +98,17 @@ public class SendOptions {
         this.channelCloseHandler = channelCloseHandler;
         return this;
     }
+
+    /**
+     * Set the channel pool to use to send messages.
+     *
+     * @param channelPool
+     * @return this {@link SendOptions} instance
+     * @since 1.1.0
+     */
+    public SendOptions channelPool(ChannelPool channelPool) {
+        this.channelMono = channelPool.getChannelMono();
+        this.channelCloseHandler = channelPool.getChannelCloseHandler();
+        return this;
+    }
 }

--- a/src/main/java/reactor/rabbitmq/SenderOptions.java
+++ b/src/main/java/reactor/rabbitmq/SenderOptions.java
@@ -161,6 +161,20 @@ public class SenderOptions {
         return this;
     }
 
+    /**
+     * Set the channel pool to use to send messages.
+     *
+     * @param channelPool
+     * @return this {@link SenderOptions} instance
+     * @since 1.1.0
+     */
+    public SenderOptions channelPool(ChannelPool channelPool) {
+        this.channelMono = channelPool.getChannelMono();
+        this.channelCloseHandler = channelPool.getChannelCloseHandler();
+        return this;
+    }
+
+
     public SenderOptions resourceManagementChannelMono(Mono<? extends Channel> resourceManagementChannelMono) {
         this.resourceManagementChannelMono = resourceManagementChannelMono;
         return this;

--- a/src/test/java/reactor/rabbitmq/LazyChannelPoolTests.java
+++ b/src/test/java/reactor/rabbitmq/LazyChannelPoolTests.java
@@ -1,0 +1,183 @@
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static java.time.Duration.ofSeconds;
+import static org.mockito.Mockito.*;
+
+class LazyChannelPoolTests {
+
+    LazyChannelPool lazyChannelPool;
+
+    Connection connection;
+    Channel channel1, channel2, channel3;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        connection = mock(Connection.class);
+        when(connection.isOpen()).thenReturn(true);
+        channel1 = channel(1);
+        channel2 = channel(2);
+        channel3 = channel(3);
+        when(connection.createChannel()).thenReturn(channel1, channel2, channel3);
+    }
+
+    @Test
+    void testChannelPoolLazyInitialization() throws Exception {
+        int maxChannelPoolSize = 2;
+        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions().maxSize(maxChannelPoolSize);
+        lazyChannelPool = new LazyChannelPool(Mono.just(connection), channelPoolOptions);
+
+        StepVerifier.withVirtualTime(() ->
+                Mono.when(
+                        // 1#
+                        useChannelFromStartUntil(ofSeconds(1)),
+                        // 2#
+                        useChannelBetween(ofSeconds(2), ofSeconds(3))
+                ))
+                .expectSubscription()
+                .thenAwait(ofSeconds(3))
+                .verifyComplete();
+
+        // Expectations, numbers on the left mean elapsed time in seconds
+        // 0 -> 1# creates channel1
+        // 1 -> 1# releases channel1, 1# adds channel1 to pool
+        // 2 -> 2# obtains channel1 from pool
+        // 3 -> 2# releases channel1, 2# adds channel1 to pool
+
+        verifyBasicPublish(channel1, 2);
+        verifyBasicPublishNever(channel2);
+        verify(channel1, never()).close();
+
+        lazyChannelPool.close();
+
+        verify(channel1).close();
+        verify(channel2, never()).close();
+    }
+
+    @Test
+    void testChannelPoolExceedsMaxPoolSize() throws Exception {
+        int maxChannelPoolSize = 2;
+        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions().maxSize(maxChannelPoolSize);
+        lazyChannelPool = new LazyChannelPool(Mono.just(connection), channelPoolOptions);
+
+        StepVerifier.withVirtualTime(() ->
+                Mono.when(
+                        // 1#
+                        useChannelBetween(ofSeconds(1), ofSeconds(4)),
+                        // 2#
+                        useChannelBetween(ofSeconds(2), ofSeconds(5)),
+                        // 3#
+                        useChannelBetween(ofSeconds(3), ofSeconds(6))
+                ))
+                .expectSubscription()
+                .thenAwait(ofSeconds(6))
+                .verifyComplete();
+
+        // Expectations, numbers on the left mean elapsed time in seconds
+        // 1 -> 1# creates channel1
+        // 2 -> 2# creates channel2
+        // 3 -> 3# creates channel3
+        // 4 -> 1# releases channel1, 1# adds channel1 to pool
+        // 5 -> 2# releases channel2, 2# adds channel2 to pool
+        // 6 -> 3# releases channel3, 3# closes channel3 (pool is full)
+
+        verifyBasicPublishOnce(channel1);
+        verifyBasicPublishOnce(channel2);
+        verifyBasicPublishOnce(channel3);
+        verify(channel1, never()).close();
+        verify(channel2, never()).close();
+        verify(channel3).close();
+
+        lazyChannelPool.close();
+
+        verify(channel1).close();
+        verify(channel2).close();
+    }
+
+    @Test
+    void testChannelPool() throws Exception {
+        int maxChannelPoolSize = 1;
+        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions().maxSize(maxChannelPoolSize);
+        lazyChannelPool = new LazyChannelPool(Mono.just(connection), channelPoolOptions);
+
+        StepVerifier.withVirtualTime(() ->
+                Mono.when(
+                        // 1#
+                        useChannelFromStartUntil(ofSeconds(3)),
+                        // 2#
+                        useChannelBetween(ofSeconds(1), ofSeconds(2)),
+                        // 3#
+                        useChannelBetween(ofSeconds(4), ofSeconds(5))
+                ))
+                .expectSubscription()
+                .thenAwait(ofSeconds(5))
+                .verifyComplete();
+        // Expectations, numbers on the left mean elapsed time in seconds
+        // 0 -> 1# creates channel1
+        // 1 -> 2# creates channel2
+        // 2 -> 2# releases channel2, 2# adds channel2 to pool
+        // 3 -> 1# releases channel1, 1# closes channel1 (pool is full)
+        // 4 -> 3# obtains channel2 from pool
+        // 5 -> 3# releases channel2, 2# adds channel2 to pool
+
+        verifyBasicPublishOnce(channel1);
+        verifyBasicPublish(channel2, 2);
+        verify(channel1).close();
+        verify(channel2, never()).close();
+
+        lazyChannelPool.close();
+        verify(channel2).close();
+    }
+
+    private Mono<Void> useChannelFromStartUntil(Duration until) {
+        return useChannelBetween(Duration.ZERO, until);
+    }
+
+    private Mono<Void> useChannelBetween(Duration from, Duration to) {
+        return Mono.delay(from)
+                .then(lazyChannelPool.getChannelMono())
+                .flatMap(channel ->
+                        Mono.just(1)
+                                .doOnNext(i -> {
+                                    try {
+                                        channel.basicPublish("", "", null, "".getBytes());
+                                    } catch (IOException e) {
+                                        e.printStackTrace();
+                                    }
+                                })
+                                .delayElement(to.minus(from))
+                                .doFinally(signalType -> lazyChannelPool.getChannelCloseHandler().accept(signalType, channel))
+                )
+                .then();
+    }
+
+    private void verifyBasicPublishNever(Channel channel) throws Exception {
+        verifyBasicPublish(channel, 0);
+    }
+
+    private void verifyBasicPublishOnce(Channel channel) throws Exception {
+        verifyBasicPublish(channel, 1);
+    }
+
+    private void verifyBasicPublish(Channel channel, int times) throws Exception {
+        verify(channel, times(times)).basicPublish(anyString(), anyString(), any(AMQP.BasicProperties.class), any(byte[].class));
+    }
+
+    private Channel channel(int channelNumber) {
+        Channel channel = mock(Channel.class);
+        when(channel.getChannelNumber()).thenReturn(channelNumber);
+        when(channel.isOpen()).thenReturn(true);
+        when(channel.getConnection()).thenReturn(connection);
+        return channel;
+    }
+}

--- a/src/test/java/reactor/rabbitmq/LazyChannelPoolTests.java
+++ b/src/test/java/reactor/rabbitmq/LazyChannelPoolTests.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import reactor.test.scheduler.VirtualTimeScheduler;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -34,7 +35,9 @@ class LazyChannelPoolTests {
     @Test
     void testChannelPoolLazyInitialization() throws Exception {
         int maxChannelPoolSize = 2;
-        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions().maxSize(maxChannelPoolSize);
+        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions()
+                .maxCacheSize(maxChannelPoolSize)
+                .subscriptionScheduler(VirtualTimeScheduler.create());
         lazyChannelPool = new LazyChannelPool(Mono.just(connection), channelPoolOptions);
 
         StepVerifier.withVirtualTime(() ->
@@ -67,7 +70,9 @@ class LazyChannelPoolTests {
     @Test
     void testChannelPoolExceedsMaxPoolSize() throws Exception {
         int maxChannelPoolSize = 2;
-        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions().maxSize(maxChannelPoolSize);
+        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions()
+                .maxCacheSize(maxChannelPoolSize)
+                .subscriptionScheduler(VirtualTimeScheduler.create());
         lazyChannelPool = new LazyChannelPool(Mono.just(connection), channelPoolOptions);
 
         StepVerifier.withVirtualTime(() ->
@@ -107,7 +112,9 @@ class LazyChannelPoolTests {
     @Test
     void testChannelPool() throws Exception {
         int maxChannelPoolSize = 1;
-        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions().maxSize(maxChannelPoolSize);
+        ChannelPoolOptions channelPoolOptions = new ChannelPoolOptions()
+                .maxCacheSize(maxChannelPoolSize)
+                .subscriptionScheduler(VirtualTimeScheduler.create());
         lazyChannelPool = new LazyChannelPool(Mono.just(connection), channelPoolOptions);
 
         StepVerifier.withVirtualTime(() ->
@@ -170,7 +177,7 @@ class LazyChannelPoolTests {
     }
 
     private void verifyBasicPublish(Channel channel, int times) throws Exception {
-        verify(channel, times(times)).basicPublish(anyString(), anyString(), any(AMQP.BasicProperties.class), any(byte[].class));
+        verify(channel, times(times)).basicPublish(anyString(), anyString(), nullable(AMQP.BasicProperties.class), any(byte[].class));
     }
 
     private Channel channel(int channelNumber) {

--- a/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
+++ b/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
@@ -19,6 +19,7 @@ package reactor.rabbitmq;
 import com.rabbitmq.client.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -587,6 +588,40 @@ public class RabbitFluxTests {
 
         verify(channelCloseHandlerInSenderOptions, never()).accept(any(SignalType.class), any(Channel.class));
         verify(channelCloseHandlerInSendOptions, times(1)).accept(any(SignalType.class), any(Channel.class));
+    }
+
+    @Test // temporary test, jvm warm-up ignored
+    @Disabled
+    public void senderWithChannelPoolPerformance() throws Exception {
+        int nbMessages = 1;
+        int count = 500;
+        int expectedSpeedupRatio = 3;
+
+        Flux<OutboundMessage> msgFlux = Flux.range(0, nbMessages).map(i -> new OutboundMessage("", queue, "".getBytes()));
+
+        ChannelPool channelPool = ChannelPoolFactory.createChannelPool(Mono.just(connection));
+        SendOptions sendOptions = new SendOptions().channelPool(channelPool);
+
+        sender = createSender();
+
+        Mono<Void> sendChannelPoolMono = Flux.range(0, count)
+                .flatMap(i -> sender.send(msgFlux, sendOptions))
+                .then();
+
+        Mono<Void> sendMono = Flux.range(0, count)
+                .flatMap(i -> sender.send(msgFlux))
+                .then();
+
+        Duration durationSendChannelPool = StepVerifier.create(sendChannelPoolMono).verifyComplete();
+        Duration durationSendChannelAlwaysCreated = StepVerifier.create(sendMono).verifyComplete();
+
+        int totalMessages = nbMessages * count * 2;
+        StepVerifier.create(consume(queue, totalMessages))
+                .expectNextCount(totalMessages)
+                .verifyComplete();
+
+        assertTrue(durationSendChannelPool.toMillis() * expectedSpeedupRatio < durationSendChannelAlwaysCreated.toMillis(),
+                String.format("Sender with channel pool is not %s times faster. Duration with channel pool is %s and without is %s", expectedSpeedupRatio, durationSendChannelPool, durationSendChannelAlwaysCreated));
     }
 
     @Test


### PR DESCRIPTION
I was going to create an issue for what you have described as 
```
    public Mono<Void> sendXXX(Publisher<OutboundMessage> messages, SendOptions options) {
        // TODO using a pool of channels?
        // would be much more efficient if send is called very often
        // less useful if seldom called, only for long or infinite message flux 
```
but finally decided to create a PR. Maybe you will find some part of it useful.
Unfortunately this is the way, we use reactor-rabbitmq most the time.
 
This PR contains 3 changes:

1. `ChannelPool` interface which gives the user full control over channel management in `Sender`. It is a wrapper for methods that have been added recently. I also provided  `LazyChannelPool` implementation.

2. JMH Microbenchmarks which compare throughput of `Sender#send` and `Sender#sendWithPublishConfirms` methods for default settings and channel pool.
The most important test parameters that impact on final score are number of concurrent threads, number of messages and max channel pool size.

3. `Sender#sendWithPublishConfirms` closes channels in a dedicated thread pool. This [new Thread(...).start()](https://github.com/reactor/reactor-rabbitmq/blob/master/src/main/java/reactor/rabbitmq/Sender.java#L549) code turned out to be a problem for channel pool usage but using thread pool solved the issue.
