### PR TITLE
Add maxInFlight in sender options

### DIFF
--- a/src/jmh/java/reactor/rabbitmq/SenderMaxInFlightBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderMaxInFlightBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.Connection;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(2)
+public class SenderMaxInFlightBenchmark {
+
+    Connection connection;
+    Sender sender;
+    String queue;
+    Flux<OutboundMessage> msgFlux;
+
+    @Param({"1", "10", "100", "1000"})
+    public int nbMessages;
+
+    @Param({"1", "256", Integer.MAX_VALUE + ""})
+    public int maxInFlight;
+
+    @Setup
+    public void setupConnection() throws Exception {
+        connection = SenderBenchmarkUtils.newConnection();
+    }
+
+    @TearDown
+    public void closeConnection() throws Exception {
+        connection.close();
+    }
+
+    @Setup(Level.Iteration)
+    public void setupSender() throws Exception {
+        queue = SenderBenchmarkUtils.declareQueue(connection);
+        sender = RabbitFlux.createSender();
+        msgFlux = SenderBenchmarkUtils.outboundMessageFlux(queue, nbMessages);
+    }
+
+    @TearDown(Level.Iteration)
+    public void tearDownSender() throws Exception {
+        SenderBenchmarkUtils.deleteQueue(connection, queue);
+        if (sender != null) {
+            sender.close();
+        }
+    }
+
+    @Benchmark
+    public void sendWithPublishConfirmsMaxInFlight(Blackhole blackhole) {
+        blackhole.consume(sender.sendWithPublishConfirms(msgFlux, new SendOptions().maxInFlight(maxInFlight)).blockLast());
+    }
+
+}

--- a/src/main/java/reactor/rabbitmq/SendOptions.java
+++ b/src/main/java/reactor/rabbitmq/SendOptions.java
@@ -19,6 +19,9 @@ package reactor.rabbitmq;
 import com.rabbitmq.client.Channel;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.concurrent.Queues;
 
 import java.time.Duration;
 import java.util.function.BiConsumer;
@@ -33,6 +36,21 @@ public class SendOptions {
     );
 
     /**
+     * The maximum number of in-flight records that are fetched
+     * from the outbound record publisher while publisher confirms are pending.
+     *
+     * @since 1.1.1
+     */
+    private int maxInFlight = Queues.SMALL_BUFFER_SIZE;
+
+    /**
+     * The scheduler used for publishing send results.
+     *
+     * @since 1.1.1
+     */
+    private Scheduler scheduler = Schedulers.newSingle("rabbitmq-sender-publishing");
+
+    /**
      * Channel mono to use to send messages.
      *
      * @since 1.1.0
@@ -45,6 +63,52 @@ public class SendOptions {
      * @since 1.1.0
      */
     private BiConsumer<SignalType, Channel> channelCloseHandler;
+
+    /**
+     * Returns the maximum number of in-flight records that are fetched
+     * from the outbound record publisher while publisher confirms are pending.
+     *
+     * @return maximum number of in-flight records
+     * @since 1.1.18
+     */
+    public int getMaxInFlight() {
+        return maxInFlight;
+    }
+
+    /**
+     * Set the maximum number of in-flight records that are fetched
+     * from the outbound record publisher while publisher confirms are pending.
+     *
+     * @param maxInFlight
+     * @return this {@link SendOptions} instance
+     * @since 1.1.1
+     */
+    public SendOptions maxInFlight(int maxInFlight) {
+        this.maxInFlight = maxInFlight;
+        return this;
+    }
+
+    /**
+     * The scheduler used for publishing send results.
+     *
+     * @return scheduler used for publishing send results
+     * @since 1.1.1
+     */
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    /**
+     * Sets the scheduler used for publishing send results.
+     *
+     * @param scheduler
+     * @return this {@link SendOptions} instance
+     * @since 1.1.1
+     */
+    public SendOptions scheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+        return this;
+    }
 
     public BiConsumer<Sender.SendContext, Exception> getExceptionHandler() {
         return exceptionHandler;

--- a/src/main/java/reactor/rabbitmq/SendOptions.java
+++ b/src/main/java/reactor/rabbitmq/SendOptions.java
@@ -21,7 +21,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.util.concurrent.Queues;
 
 import java.time.Duration;
 import java.util.function.BiConsumer;
@@ -41,14 +40,14 @@ public class SendOptions {
      *
      * @since 1.1.1
      */
-    private int maxInFlight = Queues.SMALL_BUFFER_SIZE;
+    private Integer maxInFlight;
 
     /**
      * The scheduler used for publishing send results.
      *
      * @since 1.1.1
      */
-    private Scheduler scheduler = Schedulers.newSingle("rabbitmq-sender-publishing");
+    private Scheduler scheduler = Schedulers.immediate();
 
     /**
      * Channel mono to use to send messages.
@@ -69,9 +68,9 @@ public class SendOptions {
      * from the outbound record publisher while publisher confirms are pending.
      *
      * @return maximum number of in-flight records
-     * @since 1.1.18
+     * @since 1.1.1
      */
-    public int getMaxInFlight() {
+    public Integer getMaxInFlight() {
         return maxInFlight;
     }
 
@@ -89,6 +88,22 @@ public class SendOptions {
     }
 
     /**
+     * Set the maximum number of in-flight records that are fetched
+     * from the outbound record publisher while publisher confirms are pending.
+     * Results are run on a supplied {@link Scheduler}
+     *
+     * @param maxInFlight
+     * @param scheduler
+     * @return this {@link SendOptions} instance
+     * @since 1.1.1
+     */
+    public SendOptions maxInFlight(int maxInFlight, Scheduler scheduler) {
+        this.maxInFlight = maxInFlight;
+        this.scheduler = scheduler;
+        return this;
+    }
+
+    /**
      * The scheduler used for publishing send results.
      *
      * @return scheduler used for publishing send results
@@ -96,18 +111,6 @@ public class SendOptions {
      */
     public Scheduler getScheduler() {
         return scheduler;
-    }
-
-    /**
-     * Sets the scheduler used for publishing send results.
-     *
-     * @param scheduler
-     * @return this {@link SendOptions} instance
-     * @since 1.1.1
-     */
-    public SendOptions scheduler(Scheduler scheduler) {
-        this.scheduler = scheduler;
-        return this;
     }
 
     public BiConsumer<Sender.SendContext, Exception> getExceptionHandler() {

--- a/src/main/java/reactor/rabbitmq/Sender.java
+++ b/src/main/java/reactor/rabbitmq/Sender.java
@@ -161,7 +161,8 @@ public class Sender implements AutoCloseable {
                     // so we need to complete in another thread
                     channelCloseThreadPool.execute(() -> channelCloseHandler.accept(signalType, channel));
                 }
-            }));
+            }))
+            .publishOn(sendOptions.getScheduler(), sendOptions.getMaxInFlight());
     }
 
     // package-protected for testing

--- a/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
+++ b/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
@@ -759,12 +759,13 @@ public class RabbitFluxTests {
 
         int nbMessages = 10;
         Flux<OutboundMessage> msgFlux = Flux.range(0, nbMessages).map(i -> new OutboundMessage("", queue, "".getBytes()));
-        int nbMessagesAckNack = 2;
+        int nbMessagesAckNack = 1; // why it was 2, shouldn't it be 1 ??
         CountDownLatch confirmLatch = new CountDownLatch(nbMessagesAckNack);
         sender = createSender(new SenderOptions().connectionFactory(mockConnectionFactory));
         sender.sendWithPublishConfirms(msgFlux, new SendOptions().exceptionHandler((ctx, e) -> {
             throw new RabbitFluxException(e);
-        }))
+        }))   // Before change: (onNext -> onError -> onNext )
+              // After change (maxInFlight): (onNext -> onError)
                 .subscribe(outboundMessageResult -> {
                             if (outboundMessageResult.getOutboundMessage() != null) {
                                 confirmLatch.countDown();


### PR DESCRIPTION
This can help to implement back pressure for subscribers to the flux of publish confirms and thus mitigates references #66.