### PR TITLE
[build] Backport gradle/releaser.gradle to 3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ ext {
 }
 
 apply from: "$gradleScriptDir/setup.gradle"
+apply from: "$gradleScriptDir/releaser.gradle"
 apply from: "$gradleScriptDir/doc.gradle"
 
 configurations.all {

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,0 +1,118 @@
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoField
+
+/*
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (rootProject.hasProperty("releaserDryRun") && rootProject.findProperty("releaserDryRun") != "false") {
+	println "Adding MavenLocal() for benefit of releaser dry run"
+	rootProject.repositories {
+		mavenLocal()
+	}
+}
+
+/**
+ * return a specific property value, assuming all the provided projects have it with the
+ * same value, or throw if multiple values are found
+ */
+private static def getUniquePropertyPerProject(Set<Project> projects, String property) {
+	//"multimap": dictionary of lists
+	def props = [:].withDefault {[]}
+	projects.each { props.get(it.findProperty(property)).add(it.name) }
+
+	if (props.size() != 1) {
+		throw new InvalidUserDataException("build defines multiple values for property `${property}`: ${props}")
+	}
+	return props.keySet().find()
+}
+
+//NOTE: this task is intended for rootProject with submodules
+task groupId(group: "releaser helpers", description: "output the group id of submodules, checking there is only one") {
+	doLast {
+		println getUniquePropertyPerProject(rootProject.subprojects, "group")
+	}
+}
+
+task copyReadme(type: Copy, group: "releaser helpers", description: "copies the README in preparation for search and replace") {
+	from(rootProject.rootDir) {
+		include "README.md"
+	}
+	into rootProject.buildDir
+}
+
+task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "replaces versions in README") {
+	def oldVersion = rootProject.findProperty("oldVersion")
+	def currentVersion = rootProject.findProperty("currentVersion")
+	def nextVersion = rootProject.findProperty("nextVersion")
+	def oldSnapshot = currentVersion?.replace("RELEASE", "BUILD-SNAPSHOT")
+
+	onlyIf { oldVersion != null && currentVersion != null && nextVersion != null }
+	dependsOn copyReadme
+
+	doLast {
+		println "Will replace $oldVersion with $currentVersion and $oldSnapshot with $nextVersion"
+	}
+	from(rootProject.buildDir) {
+		include 'README.md'
+	}
+	into rootProject.rootDir
+	filter { line -> line
+			.replace(oldVersion, currentVersion)
+			.replace(oldSnapshot, nextVersion)
+	}
+}
+
+String getOrGenerateBuildNumber() {
+	if (project.hasProperty("buildNumber")) {
+		return project.findProperty("buildNumber")
+	}
+	def jenkinsNumber = System.getenv("BUILD_NUMBER")
+	if (jenkinsNumber != null) {
+		return jenkinsNumber
+	}
+	ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC)
+	long secondsInDay = now.toEpochSecond() - ZonedDateTime.now(ZoneOffset.UTC).withSecond(0).withHour(0).withMinute(0).toEpochSecond()
+	String buildNumber = "$version-${now.get(ChronoField.YEAR)}${now.get(ChronoField.MONTH_OF_YEAR).toString().padLeft(2,'0')}${now.get(ChronoField.DAY_OF_MONTH).toString().padLeft(2,'0')}@${secondsInDay}"
+	println "No buildNumber set, generated: $buildNumber"
+	return buildNumber
+}
+
+task printBuildNumber() {
+	doLast {
+		println getOrGenerateBuildNumber()
+	}
+}
+
+if (project.hasProperty("artifactory_publish_password")) {
+	configure(rootProject) { p ->
+		apply plugin: "com.jfrog.artifactory"
+		def buildNumber = getOrGenerateBuildNumber()
+		artifactory {
+			contextUrl = "${artifactory_publish_contextUrl}"
+			publish {
+				repository {
+					repoKey = "${artifactory_publish_repoKey}"
+					username = "${artifactory_publish_username}"
+					password = "${artifactory_publish_password}"
+				}
+			}
+			clientConfig.setIncludeEnvVars(false)
+			clientConfig.info.setBuildName('Reactor - Releaser - Rabbitmq')
+			clientConfig.info.setBuildNumber(buildNumber)
+		}
+	}
+}


### PR DESCRIPTION
In order to be able to build whole release trains via an
external script, both for Californium and Dysprosium
(and above), the utilities in releaser.gradle should be
present in the maintenance branch. This commit backports
said utility.﻿
