### PR TITLE
Backport rest of build related changes to 1.2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,19 +19,17 @@ buildscript {
 		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
-		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11',
-				  'io.spring.gradle:propdeps-plugin:0.0.9.RELEASE'
+		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11'
 	}
 }
 plugins {
 	id 'org.asciidoctor.convert' version '1.5.6'
 	id 'me.champeau.gradle.jmh' version '0.4.7'
+	id "com.jfrog.artifactory" version "4.9.8" apply false
 }
 
 ext {
 	gradleScriptDir = "${rootProject.projectDir}/gradle"
-
-	reactorCoreVersion = "3.2.13.BUILD-SNAPSHOT"
 
 	// Logging
 	slf4jVersion = '1.7.26'
@@ -57,9 +55,8 @@ ext {
 					"https://rabbitmq.github.io/rabbitmq-java-client/api/current/",] as String[]
 }
 
-apply from: "$gradleScriptDir/setup.gradle"
-apply from: "$gradleScriptDir/releaser.gradle"
 apply from: "$gradleScriptDir/doc.gradle"
+apply from: "$gradleScriptDir/releaser.gradle"
 
 configurations.all {
 	// check for snapshot updates every time
@@ -79,8 +76,8 @@ configure(allprojects) { project ->
 	apply plugin: 'maven'
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
-	apply plugin: 'propdeps'
 	apply plugin: 'java'
+	apply from: "$gradleScriptDir/setup.gradle"
 
 	sourceCompatibility = targetCompatibility = 1.8
 
@@ -133,7 +130,7 @@ configure(rootProject) {
 	jar {
 		manifest {
 			attributes("Automatic-Module-Name": "reactor.rabbitmq",
-					   "Implementation-Version": version)
+					   "Implementation-Version": project.version)
 		}
 	}
 
@@ -142,12 +139,8 @@ configure(rootProject) {
 		systemProperty 'rabbitmqctl.bin', System.getProperty('rabbitmqctl.bin') ?: 'sudo rabbitmqctl'
 	}
 
-	artifacts {
-		archives sourcesJar
-		archives javadocJar
-		archives docsZip
-	}
-
+	//add specific task artifacts to the publication
+	publishing.publications.mavenJava.artifact(docsZip)
 }
 
 project(':reactor-rabbitmq-samples') {
@@ -179,18 +172,7 @@ project(':reactor-rabbitmq-samples') {
 		classpath = sourceSets.main.runtimeClasspath
 	}
 
-	task classpath {
-		doLast {
-			println sourceSets.main.runtimeClasspath.asPath
-		}
-	}
-
 	test {
 		useJUnitPlatform()
-	}
-
-	artifacts {
-		archives sourcesJar
-		archives javadocJar
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=1.2.1.BUILD-SNAPSHOT
+reactorCoreVersion=3.2.13.BUILD-SNAPSHOT

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -63,15 +63,18 @@ configure(rootProject) {
 			stylesheet: 'golo.css',
 			appversion: "$version",
 			'source-highlighter': 'coderay'
-
-	doLast {
-	  file("$outputDir/pdf/index.pdf").
-			  renameTo("$outputDir/pdf/rabbitmq-reference-guide-${version}.pdf")
-	}
   }
+
   task docsZip(type: Zip, dependsOn: asciidoctor) {
-	baseName = 'reactor-rabbitmq-docs'
-	from("$buildDir/asciidoc/pdf/reactor-rabbitmq-reference-guide-${version}.pdf") { into("docs/") }
+	archiveBaseName.set('reactor-rabbitmq')
+	archiveClassifier.set('docs')
+	afterEvaluate() {
+		//we copy the pdf late, when a potential customVersion has been applied to rootProject
+		from("$buildDir/asciidoc/pdf/index.pdf") {
+			into ("docs/")
+			rename("index.pdf", "reactor-rabbitmq-reference-guide-${rootProject.version}.pdf")
+		}
+	}
 	from("$buildDir/asciidoc/html5/index.html") { into("docs/") }
 	from("$buildDir/asciidoc/html5/images") { into("images/") }
   }

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -14,85 +14,88 @@
  * limitations under the License.
  */
 
-wrapper {
-	group = 'Project Setup'
-	gradleVersion = "$gradleVersion"
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
+
+jar {
+	manifest.attributes["Created-By"] = "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
+	manifest.attributes["Implementation-Title"] = project.name
+	manifest.attributes["Implementation-Version"] = project.version
+	from '../NOTICE'
 }
 
-configure(allprojects) { project ->
-
-	apply plugin: 'propdeps-maven'
-	apply plugin: 'maven'
-	install {
-		repositories.mavenInstaller {
-			customizePom(pom, project)
-		}
-	}
-
-	jar {
-		manifest.attributes["Created-By"] = "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
-		manifest.attributes["Implementation-Title"] = project.name
-		manifest.attributes["Implementation-Version"] = project.version
-		from '../NOTICE'
-	}
-
-	task sourcesJar(type: Jar) {
-		classifier = 'sources'
-		from sourceSets.main.allSource
-		from '../NOTICE'
-	}
-
-	task javadocJar(type: Jar) {
-		classifier = 'javadoc'
-		from javadoc
-		from '../NOTICE'
-	}
+task sourcesJar(type: Jar) {
+	archiveClassifier.set('sources')
+	from sourceSets.main.allSource
+	from '../NOTICE'
 }
 
-def customizePom(def pom, def gradleProject) {
-	pom.whenConfigured { generatedPom ->
-		// eliminate test-scoped dependencies (no need in maven central poms)
-		generatedPom.dependencies.removeAll { dep ->
-			dep.scope == "test"
-		}
+task javadocJar(type: Jar) {
+	archiveClassifier.set('javadoc')
+	from javadoc
+	from '../NOTICE'
+}
 
-		// sort to make pom dependencies order consistent to ease comparison of older poms
-		generatedPom.dependencies = generatedPom.dependencies.sort { dep ->
-			"$dep.scope:$dep.groupId:$dep.artifactId"
-		}
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			from components.java
+			artifact sourcesJar
+			artifact javadocJar
+			//other project-specific artifacts are added to publication in each project's specific configuration
 
-		// add all items necessary for maven central publication
-		generatedPom.project {
-			name = gradleProject.description
-			description = gradleProject.description
-			url = 'https://github.com/reactor/reactor-rabbitmq'
-			organization {
-				name = 'reactor'
-				url = 'https://github.com/reactor'
-			}
-			licenses {
-				license {
-					name 'The Apache Software License, Version 2.0'
-					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-					distribution 'repo'
+			pom {
+				afterEvaluate {
+					name = project.description
+					description = project.description
 				}
-			}
-			scm {
+
+				packaging = 'jar' //if not explicitly set, end up as `pom` in output. omitted in output if set as `jar`...
+
 				url = 'https://github.com/reactor/reactor-rabbitmq'
-				connection = 'scm:git:git://github.com/reactor/reactor-rabbitmq'
-				developerConnection = 'scm:git:git://github.com/reactor/reactor-rabbitmq'
-			}
-			developers {
-				developer {
-					id = 'acogoluegnes'
-					name = 'Arnaud Cogoluègnes'
-					email = 'acogoluegnes@pivotal.io'
+				organization {
+					name = 'reactor'
+					url = 'https://github.com/reactor'
 				}
-			}
-			issueManagement {
-				system = "GitHub Issues"
-				url = "https://github.com/reactor/reactor-rabbitmq/issues"
+				licenses {
+					license {
+						name = 'The Apache Software License, Version 2.0'
+						url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+						distribution = 'repo'
+					}
+				}
+				scm {
+					url = 'https://github.com/reactor/reactor-rabbitmq'
+					connection = 'scm:git:git://github.com/reactor/reactor-rabbitmq'
+					developerConnection = 'scm:git:git://github.com/reactor/reactor-rabbitmq'
+				}
+				developers {
+					developer {
+						id = 'acogoluegnes'
+						name = 'Arnaud Cogoluègnes'
+						email = 'acogoluegnes@pivotal.io'
+					}
+				}
+				issueManagement {
+					system = "GitHub Issues"
+					url = "https://github.com/reactor/reactor-rabbitmq/issues"
+				}
+
+				withXml {
+					//groovy magic incantation to sort dependencies alphabetically (scope/group/name..)
+					def sorted = asNode().dependencies[0].children().collect().sort { it.scope.text() + it.groupId.text() + it.artifactId.text() }
+					asNode().dependencies[0].children().with { deps ->
+						deps.clear()
+						sorted.each { deps.add(it) }
+					}
+				}
 			}
 		}
 	}
+}
+
+artifactoryPublish {
+	//don't activate the onlyIf clause below yet, so that Bamboo builds will publish stuff...
+	//onlyIf { project.hasProperty("artifactory_publish_password") }
+	publications(publishing.publications.mavenJava)
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -109,8 +109,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+rootProject.name = 'reactor-rabbitmq'
 include 'reactor-rabbitmq-samples'
 


### PR DESCRIPTION
Complements the partial backport done in 9b7b6b8 with other changes
to the build (Gradle version, switching to maven-publish, artifactory)

Cherry-pick of 04fd411, 39d991a, 6483214, cf3056f, 65124c8, 0dbfeba and
35e0ae7.

 - [build] Bump/polish Gradle, add maven-publish and artifactory (#115)
     - bumped Gradle to 5.6.4
     - removed propdeps (no optional dependency anyway)
     - removed outdated wrapper tasks and variables
     - externalized $reactorCoreVersion to `gradle.properties`
     - applied `setup.gradle` from inside configure(allProjects)
     - now applies `maven-publish` and `artifactory` plugins
     - removed useless `classpath` printing task
     - modified how the pdf is renamed when zipping docs (so that it is
     renamed late and can pick up a custom version)
     - minor polish of deprecated constructs / warnings

 - [build] Add releaser.gradle with groupId helper task (#115)

 - [build] Ensure rootProject.name is reactor-rabbitmq

 - Conditionnally add mavenLocal when releaser script is applied (#117)
    This is only activated when passing a non-false -PreleaserDryRun to
Gradle.

 - fix #119 Ensure docsZip defines a -docs classifier

 - [build] Add bumpVersionsInReadme, better Artifactory creds, buildId
    - Added a bumpVersionsInReadme task that needs to be explicitly
    executed with oldVersion, currentVersion and nextVersion properties
    - For Artifactory, we declare an explicit credentials block using
    alternate properties like artifactory_publish_xxx, that can be set via
    an env var of the form ORG_GRADLE_PROJECT_artifactory_publish_xxx.
    - We give the build info a meaningful name and id and ensure we don't
    publish environment variables.

 - [build] Fix Bamboo publications by removing onlyIf clause