### PR TITLE
[build] master is 1.5 Europium, introduce new versioning scheme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,7 @@ ext {
 	junitJupiterVersion  = '5.6.2'
 	assertjVersion = '3.15.0'
 
-	javadocLinks = ["https://docs.oracle.com/javase/7/docs/api/",
-					"https://docs.oracle.com/javaee/6/api/",
+	javadocLinks = ["https://docs.oracle.com/javase/8/docs/api/",
 					"https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
 					"https://projectreactor.io/docs/core/release/api/",
 					"https://rabbitmq.github.io/rabbitmq-java-client/api/current/",] as String[]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.4.3.BUILD-SNAPSHOT
-reactorCoreVersion=3.3.6.BUILD-SNAPSHOT
+version=1.5.0-SNAPSHOT
+reactorCoreVersion=3.4.0-SNAPSHOT

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -58,7 +58,7 @@ task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "r
 	def oldVersion = rootProject.findProperty("oldVersion")
 	def currentVersion = rootProject.findProperty("currentVersion")
 	def nextVersion = rootProject.findProperty("nextVersion")
-	def oldSnapshot = currentVersion?.replace("RELEASE", "BUILD-SNAPSHOT")
+	def oldSnapshot = currentVersion + "-SNAPSHOT"
 
 	onlyIf { oldVersion != null && currentVersion != null && nextVersion != null }
 	dependsOn copyReadme


### PR DESCRIPTION
This commit switches the effort on master from 1.4 to 1.5.0.
It also introduces a new versioning scheme, using -SNAPSHOT
instead of .BUILD-SNAPSHOT as the qualifier for snapshots.
The whole scheme is detailed in the reference documentation,
and adaptations are made to the build script to accommodate it.

See reactor/reactor#683