### PR TITLE
Consuming from a non-existing queue leads to an unrecoverable state

### DIFF
--- a/src/main/java/reactor/rabbitmq/Receiver.java
+++ b/src/main/java/reactor/rabbitmq/Receiver.java
@@ -20,7 +20,6 @@ import com.rabbitmq.client.*;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
@@ -109,56 +108,48 @@ public class Receiver implements Closeable {
     }
 
     public Flux<Delivery> consumeNoAck(final String queue, ConsumeOptions options) {
-        return Flux.create(emitter -> connectionMono.map(CHANNEL_CREATION_FUNCTION).subscribe(new BaseSubscriber<Channel>() {
-            @Override
-            protected void hookOnNext(Channel channel) {
-                try {
-                    DeliverCallback deliverCallback = (consumerTag, message) -> {
-                        emitter.next(message);
-                        if (options.getStopConsumingBiFunction().apply(emitter.requestedFromDownstream(), message)) {
-                            emitter.complete();
-                        }
-                    };
-                    AtomicBoolean basicCancel = new AtomicBoolean(true);
-                    CancelCallback cancelCallback = consumerTag -> {
-                        LOGGER.info("Flux consumer {} has been cancelled", consumerTag);
-                        basicCancel.set(false);
+        return Flux.create(emitter -> connectionMono.map(CHANNEL_CREATION_FUNCTION).subscribe(channel -> {
+            try {
+                DeliverCallback deliverCallback = (consumerTag, message) -> {
+                    emitter.next(message);
+                    if (options.getStopConsumingBiFunction().apply(emitter.requestedFromDownstream(), message)) {
                         emitter.complete();
-                    };
+                    }
+                };
+                AtomicBoolean basicCancel = new AtomicBoolean(true);
+                CancelCallback cancelCallback = consumerTag -> {
+                    LOGGER.info("Flux consumer {} has been cancelled", consumerTag);
+                    basicCancel.set(false);
+                    emitter.complete();
+                };
 
-                    completeOnChannelShutdown(channel, emitter);
+                completeOnChannelShutdown(channel, emitter);
 
-                    final String consumerTag = channel.basicConsume(queue, true, options.getConsumerTag(), deliverCallback, cancelCallback);
-                    AtomicBoolean cancelled = new AtomicBoolean(false);
-                    LOGGER.info("Consumer {} consuming from {} has been registered", consumerTag, queue);
-                    emitter.onDispose(() -> {
-                        LOGGER.info("Cancelling consumer {} consuming from {}", consumerTag, queue);
-                        if (cancelled.compareAndSet(false, true)) {
-                            try {
-                                if (channel.isOpen() && channel.getConnection().isOpen()) {
-                                    if (basicCancel.compareAndSet(true, false)) {
-                                        channel.basicCancel(consumerTag);
-                                    }
-                                    channel.close();
+                final String consumerTag = channel.basicConsume(queue, true, options.getConsumerTag(), deliverCallback, cancelCallback);
+                AtomicBoolean cancelled = new AtomicBoolean(false);
+                LOGGER.info("Consumer {} consuming from {} has been registered", consumerTag, queue);
+                emitter.onDispose(() -> {
+                    LOGGER.info("Cancelling consumer {} consuming from {}", consumerTag, queue);
+                    if (cancelled.compareAndSet(false, true)) {
+                        try {
+                            if (channel.isOpen() && channel.getConnection().isOpen()) {
+                                if (basicCancel.compareAndSet(true, false)) {
+                                    channel.basicCancel(consumerTag);
                                 }
-                            } catch (TimeoutException | IOException e) {
-                                // Not sure what to do, not much we can do,
-                                // logging should be enough.
-                                // Maybe one good reason to introduce an exception handler to choose more easily.
-                                LOGGER.warn("Error while closing channel: " + e.getMessage());
+                                channel.close();
                             }
+                        } catch (TimeoutException | IOException e) {
+                            // Not sure what to do, not much we can do,
+                            // logging should be enough.
+                            // Maybe one good reason to introduce an exception handler to choose more easily.
+                            LOGGER.warn("Error while closing channel: " + e.getMessage());
                         }
-                    });
-                } catch (IOException e) {
-                    throw new RabbitFluxException(e);
-                }
+                    }
+                });
+            } catch (Exception e) {
+                emitter.error(new RabbitFluxException(e));
             }
-
-            @Override
-            protected void hookOnError(Throwable throwable) {
-                emitter.error(throwable);
-            }
-        }), options.getOverflowStrategy());
+        }, emitter::error), options.getOverflowStrategy());
     }
 
     protected void completeOnChannelShutdown(Channel channel, FluxSink<?> emitter) {
@@ -187,64 +178,56 @@ public class Receiver implements Closeable {
     public Flux<AcknowledgableDelivery> consumeManualAck(final String queue, ConsumeOptions options) {
         // TODO track flux so it can be disposed when the sender is closed?
         // could be also developer responsibility
-        return Flux.create(emitter -> connectionMono.map(CHANNEL_CREATION_FUNCTION).subscribe(new BaseSubscriber<Channel>() {
-            @Override
-            protected void hookOnNext(Channel channel) {
-                try {
-                    if (options.getQos() != 0) {
-                        channel.basicQos(options.getQos());
-                    }
-
-                    DeliverCallback deliverCallback = (consumerTag, message) -> {
-                        AcknowledgableDelivery delivery = new AcknowledgableDelivery(message, channel, options.getExceptionHandler());
-                        if (options.getHookBeforeEmitBiFunction().apply(emitter.requestedFromDownstream(), delivery)) {
-                            emitter.next(delivery);
-                        }
-                        if (options.getStopConsumingBiFunction().apply(emitter.requestedFromDownstream(), message)) {
-                            emitter.complete();
-                        }
-                    };
-
-                    AtomicBoolean basicCancel = new AtomicBoolean(true);
-                    CancelCallback cancelCallback = consumerTag -> {
-                        LOGGER.info("Flux consumer {} has been cancelled", consumerTag);
-                        basicCancel.set(false);
-                        emitter.complete();
-                    };
-
-                    completeOnChannelShutdown(channel, emitter);
-
-                    final String consumerTag = channel.basicConsume(queue, false, options.getConsumerTag(), deliverCallback, cancelCallback);
-                    AtomicBoolean cancelled = new AtomicBoolean(false);
-                    LOGGER.info("Consumer {} consuming from {} has been registered", consumerTag, queue);
-                    emitter.onDispose(() -> {
-                        LOGGER.info("Cancelling consumer {} consuming from {}", consumerTag, queue);
-                        if (cancelled.compareAndSet(false, true)) {
-                            try {
-                                if (channel.isOpen() && channel.getConnection().isOpen()) {
-                                    if (basicCancel.compareAndSet(true, false)) {
-                                        channel.basicCancel(consumerTag);
-                                    }
-                                    channel.close();
-                                }
-                            } catch (TimeoutException | IOException e) {
-                                // Not sure what to do, not much we can do,
-                                // logging should be enough.
-                                // Maybe one good reason to introduce an exception handler to choose more easily.
-                                LOGGER.warn("Error while closing channel: " + e.getMessage());
-                            }
-                        }
-                    });
-                } catch (IOException e) {
-                    throw new RabbitFluxException(e);
+        return Flux.create(emitter -> connectionMono.map(CHANNEL_CREATION_FUNCTION).subscribe(channel -> {
+            try {
+                if (options.getQos() != 0) {
+                    channel.basicQos(options.getQos());
                 }
-            }
 
-            @Override
-            protected void hookOnError(Throwable throwable) {
-                emitter.error(throwable);
+                DeliverCallback deliverCallback = (consumerTag, message) -> {
+                    AcknowledgableDelivery delivery = new AcknowledgableDelivery(message, channel, options.getExceptionHandler());
+                    if (options.getHookBeforeEmitBiFunction().apply(emitter.requestedFromDownstream(), delivery)) {
+                        emitter.next(delivery);
+                    }
+                    if (options.getStopConsumingBiFunction().apply(emitter.requestedFromDownstream(), message)) {
+                        emitter.complete();
+                    }
+                };
+
+                AtomicBoolean basicCancel = new AtomicBoolean(true);
+                CancelCallback cancelCallback = consumerTag -> {
+                    LOGGER.info("Flux consumer {} has been cancelled", consumerTag);
+                    basicCancel.set(false);
+                    emitter.complete();
+                };
+
+                completeOnChannelShutdown(channel, emitter);
+
+                final String consumerTag = channel.basicConsume(queue, false, options.getConsumerTag(), deliverCallback, cancelCallback);
+                AtomicBoolean cancelled = new AtomicBoolean(false);
+                LOGGER.info("Consumer {} consuming from {} has been registered", consumerTag, queue);
+                emitter.onDispose(() -> {
+                    LOGGER.info("Cancelling consumer {} consuming from {}", consumerTag, queue);
+                    if (cancelled.compareAndSet(false, true)) {
+                        try {
+                            if (channel.isOpen() && channel.getConnection().isOpen()) {
+                                if (basicCancel.compareAndSet(true, false)) {
+                                    channel.basicCancel(consumerTag);
+                                }
+                                channel.close();
+                            }
+                        } catch (TimeoutException | IOException e) {
+                            // Not sure what to do, not much we can do,
+                            // logging should be enough.
+                            // Maybe one good reason to introduce an exception handler to choose more easily.
+                            LOGGER.warn("Error while closing channel: " + e.getMessage());
+                        }
+                    }
+                });
+            } catch (Exception e) {
+                emitter.error(new RabbitFluxException(e));
             }
-        }), options.getOverflowStrategy());
+        }, emitter::error), options.getOverflowStrategy());
     }
 
     // TODO consume with dynamic QoS and/or batch ack

--- a/src/main/java/reactor/rabbitmq/Receiver.java
+++ b/src/main/java/reactor/rabbitmq/Receiver.java
@@ -20,6 +20,7 @@ import com.rabbitmq.client.*;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
@@ -108,48 +109,56 @@ public class Receiver implements Closeable {
     }
 
     public Flux<Delivery> consumeNoAck(final String queue, ConsumeOptions options) {
-        return Flux.create(emitter -> connectionMono.map(CHANNEL_CREATION_FUNCTION).subscribe(channel -> {
-            try {
-                DeliverCallback deliverCallback = (consumerTag, message) -> {
-                    emitter.next(message);
-                    if (options.getStopConsumingBiFunction().apply(emitter.requestedFromDownstream(), message)) {
-                        emitter.complete();
-                    }
-                };
-                AtomicBoolean basicCancel = new AtomicBoolean(true);
-                CancelCallback cancelCallback = consumerTag -> {
-                    LOGGER.info("Flux consumer {} has been cancelled", consumerTag);
-                    basicCancel.set(false);
-                    emitter.complete();
-                };
-
-                completeOnChannelShutdown(channel, emitter);
-
-                final String consumerTag = channel.basicConsume(queue, true, options.getConsumerTag(), deliverCallback, cancelCallback);
-                AtomicBoolean cancelled = new AtomicBoolean(false);
-                LOGGER.info("Consumer {} consuming from {} has been registered", consumerTag, queue);
-                emitter.onDispose(() -> {
-                    LOGGER.info("Cancelling consumer {} consuming from {}", consumerTag, queue);
-                    if (cancelled.compareAndSet(false, true)) {
-                        try {
-                            if (channel.isOpen() && channel.getConnection().isOpen()) {
-                                if (basicCancel.compareAndSet(true, false)) {
-                                    channel.basicCancel(consumerTag);
-                                }
-                                channel.close();
-                            }
-                        } catch (TimeoutException | IOException e) {
-                            // Not sure what to do, not much we can do,
-                            // logging should be enough.
-                            // Maybe one good reason to introduce an exception handler to choose more easily.
-                            LOGGER.warn("Error while closing channel: " + e.getMessage());
+        return Flux.create(emitter -> connectionMono.map(CHANNEL_CREATION_FUNCTION).subscribe(new BaseSubscriber<Channel>() {
+            @Override
+            protected void hookOnNext(Channel channel) {
+                try {
+                    DeliverCallback deliverCallback = (consumerTag, message) -> {
+                        emitter.next(message);
+                        if (options.getStopConsumingBiFunction().apply(emitter.requestedFromDownstream(), message)) {
+                            emitter.complete();
                         }
-                    }
-                });
-            } catch (IOException e) {
-                throw new RabbitFluxException(e);
+                    };
+                    AtomicBoolean basicCancel = new AtomicBoolean(true);
+                    CancelCallback cancelCallback = consumerTag -> {
+                        LOGGER.info("Flux consumer {} has been cancelled", consumerTag);
+                        basicCancel.set(false);
+                        emitter.complete();
+                    };
+
+                    completeOnChannelShutdown(channel, emitter);
+
+                    final String consumerTag = channel.basicConsume(queue, true, options.getConsumerTag(), deliverCallback, cancelCallback);
+                    AtomicBoolean cancelled = new AtomicBoolean(false);
+                    LOGGER.info("Consumer {} consuming from {} has been registered", consumerTag, queue);
+                    emitter.onDispose(() -> {
+                        LOGGER.info("Cancelling consumer {} consuming from {}", consumerTag, queue);
+                        if (cancelled.compareAndSet(false, true)) {
+                            try {
+                                if (channel.isOpen() && channel.getConnection().isOpen()) {
+                                    if (basicCancel.compareAndSet(true, false)) {
+                                        channel.basicCancel(consumerTag);
+                                    }
+                                    channel.close();
+                                }
+                            } catch (TimeoutException | IOException e) {
+                                // Not sure what to do, not much we can do,
+                                // logging should be enough.
+                                // Maybe one good reason to introduce an exception handler to choose more easily.
+                                LOGGER.warn("Error while closing channel: " + e.getMessage());
+                            }
+                        }
+                    });
+                } catch (IOException e) {
+                    throw new RabbitFluxException(e);
+                }
             }
-        }, emitter::error), options.getOverflowStrategy());
+
+            @Override
+            protected void hookOnError(Throwable throwable) {
+                emitter.error(throwable);
+            }
+        }), options.getOverflowStrategy());
     }
 
     protected void completeOnChannelShutdown(Channel channel, FluxSink<?> emitter) {
@@ -178,56 +187,64 @@ public class Receiver implements Closeable {
     public Flux<AcknowledgableDelivery> consumeManualAck(final String queue, ConsumeOptions options) {
         // TODO track flux so it can be disposed when the sender is closed?
         // could be also developer responsibility
-        return Flux.create(emitter -> connectionMono.map(CHANNEL_CREATION_FUNCTION).subscribe(channel -> {
-            try {
-                if (options.getQos() != 0) {
-                    channel.basicQos(options.getQos());
-                }
-
-                DeliverCallback deliverCallback = (consumerTag, message) -> {
-                    AcknowledgableDelivery delivery = new AcknowledgableDelivery(message, channel, options.getExceptionHandler());
-                    if (options.getHookBeforeEmitBiFunction().apply(emitter.requestedFromDownstream(), delivery)) {
-                        emitter.next(delivery);
+        return Flux.create(emitter -> connectionMono.map(CHANNEL_CREATION_FUNCTION).subscribe(new BaseSubscriber<Channel>() {
+            @Override
+            protected void hookOnNext(Channel channel) {
+                try {
+                    if (options.getQos() != 0) {
+                        channel.basicQos(options.getQos());
                     }
-                    if (options.getStopConsumingBiFunction().apply(emitter.requestedFromDownstream(), message)) {
-                        emitter.complete();
-                    }
-                };
 
-                AtomicBoolean basicCancel = new AtomicBoolean(true);
-                CancelCallback cancelCallback = consumerTag -> {
-                    LOGGER.info("Flux consumer {} has been cancelled", consumerTag);
-                    basicCancel.set(false);
-                    emitter.complete();
-                };
-
-                completeOnChannelShutdown(channel, emitter);
-
-                final String consumerTag = channel.basicConsume(queue, false, options.getConsumerTag(), deliverCallback, cancelCallback);
-                AtomicBoolean cancelled = new AtomicBoolean(false);
-                LOGGER.info("Consumer {} consuming from {} has been registered", consumerTag, queue);
-                emitter.onDispose(() -> {
-                    LOGGER.info("Cancelling consumer {} consuming from {}", consumerTag, queue);
-                    if (cancelled.compareAndSet(false, true)) {
-                        try {
-                            if (channel.isOpen() && channel.getConnection().isOpen()) {
-                                if (basicCancel.compareAndSet(true, false)) {
-                                    channel.basicCancel(consumerTag);
-                                }
-                                channel.close();
-                            }
-                        } catch (TimeoutException | IOException e) {
-                            // Not sure what to do, not much we can do,
-                            // logging should be enough.
-                            // Maybe one good reason to introduce an exception handler to choose more easily.
-                            LOGGER.warn("Error while closing channel: " + e.getMessage());
+                    DeliverCallback deliverCallback = (consumerTag, message) -> {
+                        AcknowledgableDelivery delivery = new AcknowledgableDelivery(message, channel, options.getExceptionHandler());
+                        if (options.getHookBeforeEmitBiFunction().apply(emitter.requestedFromDownstream(), delivery)) {
+                            emitter.next(delivery);
                         }
-                    }
-                });
-            } catch (IOException e) {
-                throw new RabbitFluxException(e);
+                        if (options.getStopConsumingBiFunction().apply(emitter.requestedFromDownstream(), message)) {
+                            emitter.complete();
+                        }
+                    };
+
+                    AtomicBoolean basicCancel = new AtomicBoolean(true);
+                    CancelCallback cancelCallback = consumerTag -> {
+                        LOGGER.info("Flux consumer {} has been cancelled", consumerTag);
+                        basicCancel.set(false);
+                        emitter.complete();
+                    };
+
+                    completeOnChannelShutdown(channel, emitter);
+
+                    final String consumerTag = channel.basicConsume(queue, false, options.getConsumerTag(), deliverCallback, cancelCallback);
+                    AtomicBoolean cancelled = new AtomicBoolean(false);
+                    LOGGER.info("Consumer {} consuming from {} has been registered", consumerTag, queue);
+                    emitter.onDispose(() -> {
+                        LOGGER.info("Cancelling consumer {} consuming from {}", consumerTag, queue);
+                        if (cancelled.compareAndSet(false, true)) {
+                            try {
+                                if (channel.isOpen() && channel.getConnection().isOpen()) {
+                                    if (basicCancel.compareAndSet(true, false)) {
+                                        channel.basicCancel(consumerTag);
+                                    }
+                                    channel.close();
+                                }
+                            } catch (TimeoutException | IOException e) {
+                                // Not sure what to do, not much we can do,
+                                // logging should be enough.
+                                // Maybe one good reason to introduce an exception handler to choose more easily.
+                                LOGGER.warn("Error while closing channel: " + e.getMessage());
+                            }
+                        }
+                    });
+                } catch (IOException e) {
+                    throw new RabbitFluxException(e);
+                }
             }
-        }, emitter::error), options.getOverflowStrategy());
+
+            @Override
+            protected void hookOnError(Throwable throwable) {
+                emitter.error(throwable);
+            }
+        }), options.getOverflowStrategy());
     }
 
     // TODO consume with dynamic QoS and/or batch ack

--- a/src/test/java/reactor/rabbitmq/ReceiverTests.java
+++ b/src/test/java/reactor/rabbitmq/ReceiverTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.Disposable;
+import reactor.test.StepVerifier;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -159,5 +160,25 @@ public class ReceiverTests {
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
         receiver.close();
         receiver.close();
+    }
+
+    @Test
+    public void consumeNoAckEmitsErrorWhenQueueDoesNotExist() {
+        Receiver receiver = createReceiver();
+
+        StepVerifier
+                .create(receiver.consumeNoAck("not-existing-queue"))
+                .expectError(RabbitFluxException.class)
+                .verify(Duration.ofSeconds(3));
+    }
+
+    @Test
+    public void consumeManualAckEmitsErrorWhenQueueDoesNotExist() {
+        Receiver receiver = createReceiver();
+
+        StepVerifier
+                .create(receiver.consumeNoAck("not-existing-queue"))
+                .expectError(RabbitFluxException.class)
+                .verify(Duration.ofSeconds(3));
     }
 }


### PR DESCRIPTION
There is an exception being thrown inside consumers of subscribe methods in consumeNoAck and consumeManualAck. This leads to un unrecoverable state. The exception is not emitted as error.

I used BaseSubscriber in Mono.subscribe() method of each consume method so the exception thrown in consumer is then handled by errorConsumer.

The problem was discovered in our project when Receiver was consuming from a queue that didn't exist. This is the same issue as described in https://github.com/reactor/reactor-core/issues/1995 and usage of BaseSubscriber is a workaround.