### PR TITLE
Add delayed exchange and outbound message support

### DIFF
--- a/src/main/java/reactor/rabbitmq/DelayedExchangeSpecification.java
+++ b/src/main/java/reactor/rabbitmq/DelayedExchangeSpecification.java
@@ -1,0 +1,44 @@
+package reactor.rabbitmq;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Fluent API to specify creation of an exchange with delayed feature.
+ * The <a href="https://github.com/rabbitmq/rabbitmq-delayed-message-exchange">delayed message plugin</a>
+ * need to be enabled for RabbitMQ.
+ */
+public class DelayedExchangeSpecification extends ExchangeSpecification {
+
+    private static final String DELAYED_TYPE = "x-delayed-message";
+    private static final String DELAYED_ARGUMENT_KEY = "x-delayed-type";
+
+    public DelayedExchangeSpecification() {
+        type(super.getType());
+    }
+
+    public static ExchangeSpecification exchange() {
+        return new DelayedExchangeSpecification();
+    }
+
+    public static ExchangeSpecification exchange(String name) {
+        return new DelayedExchangeSpecification().name(name);
+    }
+
+    @Override
+    public DelayedExchangeSpecification type(String type) {
+        Map<String, Object> args = getArguments();
+        if (args == null) {
+            args = new HashMap<>();
+        }
+        args.put(DELAYED_ARGUMENT_KEY, type);
+        arguments(args);
+        return this;
+    }
+
+    @Override
+    public String getType() {
+        return DELAYED_TYPE;
+    }
+
+}

--- a/src/main/java/reactor/rabbitmq/DelayedOutboundMessage.java
+++ b/src/main/java/reactor/rabbitmq/DelayedOutboundMessage.java
@@ -1,0 +1,50 @@
+package reactor.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import reactor.util.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Delayed outbound message meant to be sent by a {@link Sender}.
+ * The <a href="https://github.com/rabbitmq/rabbitmq-delayed-message-exchange">delayed message plugin</a>
+ * need to be enabled for RabbitMQ.
+ */
+public class DelayedOutboundMessage extends OutboundMessage {
+
+    public static final String DELAYED_HEADER_KEY = "x-delay";
+
+    /**
+     * @param delayMillis Delay time in milliseconds
+     */
+    public DelayedOutboundMessage(String exchange, String routingKey, long delayMillis, byte[] body) {
+        super(exchange, routingKey, delayedProperties(null, delayMillis), body);
+    }
+
+    /**
+     * @param delayMillis Delay time in milliseconds
+     */
+    public DelayedOutboundMessage(String exchange, String routingKey, long delayMillis, BasicProperties properties, byte[] body) {
+        super(exchange, routingKey, delayedProperties(properties, delayMillis), body);
+    }
+
+    private static BasicProperties delayedProperties(@Nullable AMQP.BasicProperties source, long delayMillis) {
+        AMQP.BasicProperties.Builder builder;
+        if (source != null) {
+            builder = source.builder();
+        } else {
+            builder = new BasicProperties.Builder();
+        }
+        Map<String, Object> headers;
+        if (source != null) {
+            headers = source.getHeaders();
+        } else {
+            headers = new HashMap<>();
+        }
+        headers.put(DELAYED_HEADER_KEY, delayMillis);
+        return builder.headers(headers).build();
+    }
+
+}


### PR DESCRIPTION
This PR adds delayed feature to `Exchange` and `Message` components.

The new test [`SenderTests#createDelayedExchangeBeforePublishing`](https://github.com/reactor/reactor-rabbitmq/pull/152/files#diff-ef292aeaca2e42b75fa24aefcfac47c03e1c3ade0e2305f476798258864d2013R128) had passed in local environment, however, I don't know whether the delayed plugin was enabled in testing environment of reactor. If the plugin is equipped, it can be involved to test cases with uncommenting `@Test`. 