### PR TITLE
[backport] Remove jcenter() from build in 1.4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
 	repositories {
-		jcenter()
+		mavenCentral()
 		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
@@ -67,7 +67,6 @@ configure(allprojects) { project ->
 
 	repositories {
 		mavenCentral()
-		jcenter()
 		maven { url 'https://repo.spring.io/snapshot' }
 	}
 


### PR DESCRIPTION
This is a backport of 5b68ba0.

See reactor/reactor#695.
