### PR TITLE
Renamed branch master to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 on:
   push:
     branches: # For branches, better to list them explicitly than regexp include
-      - master
+      - main
       - 1.4.x
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -3,7 +3,7 @@ name: Build (Linux)
 on:
   pull_request:
     branches:
-      - master
+      - main
       - 1.4.x
 
 jobs:

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -96,7 +96,7 @@ include::{test-examples}/ApiGuideSender.java[tag=send-flux]
 <2> If the sending fails, log an error
 <3> Subscribe to trigger the actual flow of records from `outboundFlux` to RabbitMQ.
 
-See https://github.com/reactor/reactor-rabbitmq/blob/master/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java[SampleSender]
+See https://github.com/reactor/reactor-rabbitmq/blob/main/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java[SampleSender]
 for a full code listing for a `Sender`.
 
 ==== Managing resources (exchanges, queues, and bindings)
@@ -368,7 +368,7 @@ The inbound RabbitMQ `Flux` is ready to be consumed.
 Each inbound message delivered by the Flux is represented as a
 https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/Delivery.html[`Delivery`].
 
-See https://github.com/reactor/reactor-rabbitmq/blob/master/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleReceiver.java[`SampleReceiver`]
+See https://github.com/reactor/reactor-rabbitmq/blob/main/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleReceiver.java[`SampleReceiver`]
 for a full code listing for a `Receiver`.
 
 ==== Consuming options
@@ -599,7 +599,7 @@ include::{test-examples}/ApiGuideSender.java[tag=channel-pool]
 Note it is developer's responsibility to close the pool when it is no longer
 necessary, typically at application shutdown.
 
-https://github.com/reactor/reactor-rabbitmq/tree/master/src/jmh/java/reactor/rabbitmq[Micro-benchmarks]
+https://github.com/reactor/reactor-rabbitmq/tree/main/src/jmh/java/reactor/rabbitmq[Micro-benchmarks]
 revealed channel pooling performs much better for sending short sequence
 of messages (1 to 10) repeatedly, without publisher confirms. With longer sequence
 of messages (100 or more), channel pooling can perform worse than

--- a/src/docs/asciidoc/getting-started.adoc
+++ b/src/docs/asciidoc/getting-started.adoc
@@ -30,7 +30,7 @@ Download Reactor RabbitMQ from https://github.com/reactor/reactor-rabbitmq/.
 
 ===== Sample Sender
 
-The https://github.com/reactor/reactor-rabbitmq/blob/master/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java[`SampleSender`]
+The https://github.com/reactor/reactor-rabbitmq/blob/main/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java[`SampleSender`]
 code is on GitHub.
 
 Run the sample sender:
@@ -66,7 +66,7 @@ when the publisher confirmation is received from the broker.
 
 ===== Sample Receiver
 
-The https://github.com/reactor/reactor-rabbitmq/blob/master/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleReceiver.java[`SampleReceiver`]
+The https://github.com/reactor/reactor-rabbitmq/blob/main/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleReceiver.java[`SampleReceiver`]
 code is on GitHub.
 
 Run the sample receiver:
@@ -101,7 +101,7 @@ the message content in the console.
 
 ===== Sample Spring Boot Application
 
-The https://github.com/reactor/reactor-rabbitmq/blob/master/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SpringBootSample.java[`SpringBootSample`]
+The https://github.com/reactor/reactor-rabbitmq/blob/main/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SpringBootSample.java[`SpringBootSample`]
 code is on GitHub.
 
 Run the sample Spring Boot application:


### PR DESCRIPTION
This is in preparation of renaming master to main.
Targeting 1.4.x in order to ensure documentation and build are aligned on both
maintained branches.﻿