### PR TITLE
[build] AsciidoctorConvert plugin 1.5.6 not found, bump to 1.5.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,11 @@ buildscript {
 		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
-		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11'
+		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.4'
 	}
 }
 plugins {
-	id 'org.asciidoctor.convert' version '1.5.6'
+	id 'org.asciidoctor.convert' version '1.5.12'
 	id 'me.champeau.gradle.jmh' version '0.4.7'
 	id "com.jfrog.artifactory" version "4.15.2" apply false
 }


### PR DESCRIPTION
Encountered this while working on copyright PR: the project wasn't even building, complaining that plugin's version 1.5.6 couldn't be found in configured repositories... Was the same in reactor-kafka, so I similarly bumped to 1.5.4 (for pdf) and 1.5.12 (for convert). In the case of reactor-kafka, the documentation production was verified so this should be all good.