### PR TITLE
[chores] Copyright switch Pivotal to VMware, polish headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Pivotal
+   Copyright 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -172,4 +172,4 @@ for the support timeline of this library.
 
 Reactor RabbitMQ is [Apache 2.0 licensed](https://www.apache.org/licenses/LICENSE-2.0.html).
 
-_Sponsored by [Pivotal](https://pivotal.io)_
+_Sponsored by [VMware](https://tanzu.vmware.com/)_

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 configure(rootProject) {
   apply plugin: "java"
   apply plugin: 'org.asciidoctor.convert'

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,9 +1,5 @@
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.temporal.ChronoField
-
 /*
- * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +13,10 @@ import java.time.temporal.ChronoField
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoField
 
 if (rootProject.hasProperty("releaserDryRun") && rootProject.findProperty("releaserDryRun") != "false") {
 	println "Adding MavenLocal() for benefit of releaser dry run"

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleReceiver.java
+++ b/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleReceiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleReceiver.java
+++ b/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java
+++ b/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java
+++ b/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SampleSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SpringBootSample.java
+++ b/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SpringBootSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SpringBootSample.java
+++ b/reactor-rabbitmq-samples/src/main/java/reactor/rabbitmq/samples/SpringBootSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-rabbitmq-samples/src/main/resources/logback.xml
+++ b/reactor-rabbitmq-samples/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-rabbitmq-samples/src/main/resources/logback.xml
+++ b/reactor-rabbitmq-samples/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactor-rabbitmq-samples/src/test/java/reactor/rabbitmq/samples/SamplesTest.java
+++ b/reactor-rabbitmq-samples/src/test/java/reactor/rabbitmq/samples/SamplesTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-rabbitmq-samples/src/test/java/reactor/rabbitmq/samples/SamplesTest.java
+++ b/reactor-rabbitmq-samples/src/test/java/reactor/rabbitmq/samples/SamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-rabbitmq-samples/src/test/java/reactor/rabbitmq/samples/SpringBootSampleTest.java
+++ b/reactor-rabbitmq-samples/src/test/java/reactor/rabbitmq/samples/SpringBootSampleTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-rabbitmq-samples/src/test/java/reactor/rabbitmq/samples/SpringBootSampleTest.java
+++ b/reactor-rabbitmq-samples/src/test/java/reactor/rabbitmq/samples/SpringBootSampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-rabbitmq-samples/src/test/resources/logback-test.xml
+++ b/reactor-rabbitmq-samples/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/reactor-rabbitmq-samples/src/test/resources/logback-test.xml
+++ b/reactor-rabbitmq-samples/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 rootProject.name = 'reactor-rabbitmq'
 include 'reactor-rabbitmq-samples'
 

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/api/stylesheet.css
+++ b/src/api/stylesheet.css
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/api/stylesheet.css
+++ b/src/api/stylesheet.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/jmh/java/reactor/rabbitmq/SenderBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderBenchmark.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/jmh/java/reactor/rabbitmq/SenderBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/jmh/java/reactor/rabbitmq/SenderBenchmarkUtils.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderBenchmarkUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/jmh/java/reactor/rabbitmq/SenderBenchmarkUtils.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderBenchmarkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/jmh/java/reactor/rabbitmq/SenderMaxInFlightBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderMaxInFlightBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/jmh/java/reactor/rabbitmq/SenderWithLazyChannelPoolBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderWithLazyChannelPoolBenchmark.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/jmh/java/reactor/rabbitmq/SenderWithLazyChannelPoolBenchmark.java
+++ b/src/jmh/java/reactor/rabbitmq/SenderWithLazyChannelPoolBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/AcknowledgableDelivery.java
+++ b/src/main/java/reactor/rabbitmq/AcknowledgableDelivery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/AcknowledgableDelivery.java
+++ b/src/main/java/reactor/rabbitmq/AcknowledgableDelivery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/BindingSpecification.java
+++ b/src/main/java/reactor/rabbitmq/BindingSpecification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/BindingSpecification.java
+++ b/src/main/java/reactor/rabbitmq/BindingSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ChannelCloseHandlers.java
+++ b/src/main/java/reactor/rabbitmq/ChannelCloseHandlers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ChannelCloseHandlers.java
+++ b/src/main/java/reactor/rabbitmq/ChannelCloseHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ChannelPool.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPool.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ChannelPool.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ChannelPoolFactory.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPoolFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ChannelPoolFactory.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPoolFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ChannelPoolOptions.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPoolOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ChannelPoolOptions.java
+++ b/src/main/java/reactor/rabbitmq/ChannelPoolOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ChannelProxy.java
+++ b/src/main/java/reactor/rabbitmq/ChannelProxy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ChannelProxy.java
+++ b/src/main/java/reactor/rabbitmq/ChannelProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ConsumeOptions.java
+++ b/src/main/java/reactor/rabbitmq/ConsumeOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ConsumeOptions.java
+++ b/src/main/java/reactor/rabbitmq/ConsumeOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/CorrelableOutboundMessage.java
+++ b/src/main/java/reactor/rabbitmq/CorrelableOutboundMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/CorrelableOutboundMessage.java
+++ b/src/main/java/reactor/rabbitmq/CorrelableOutboundMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ExceptionHandlers.java
+++ b/src/main/java/reactor/rabbitmq/ExceptionHandlers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ExceptionHandlers.java
+++ b/src/main/java/reactor/rabbitmq/ExceptionHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware, Inc. or its affiliates.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ExchangeSpecification.java
+++ b/src/main/java/reactor/rabbitmq/ExchangeSpecification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ExchangeSpecification.java
+++ b/src/main/java/reactor/rabbitmq/ExchangeSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/Helpers.java
+++ b/src/main/java/reactor/rabbitmq/Helpers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/Helpers.java
+++ b/src/main/java/reactor/rabbitmq/Helpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/IdempotentClosedConnection.java
+++ b/src/main/java/reactor/rabbitmq/IdempotentClosedConnection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/IdempotentClosedConnection.java
+++ b/src/main/java/reactor/rabbitmq/IdempotentClosedConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/LazyChannelPool.java
+++ b/src/main/java/reactor/rabbitmq/LazyChannelPool.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/LazyChannelPool.java
+++ b/src/main/java/reactor/rabbitmq/LazyChannelPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/OutboundMessage.java
+++ b/src/main/java/reactor/rabbitmq/OutboundMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/OutboundMessage.java
+++ b/src/main/java/reactor/rabbitmq/OutboundMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/OutboundMessageResult.java
+++ b/src/main/java/reactor/rabbitmq/OutboundMessageResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/OutboundMessageResult.java
+++ b/src/main/java/reactor/rabbitmq/OutboundMessageResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/QueueSpecification.java
+++ b/src/main/java/reactor/rabbitmq/QueueSpecification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/QueueSpecification.java
+++ b/src/main/java/reactor/rabbitmq/QueueSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/RabbitFlux.java
+++ b/src/main/java/reactor/rabbitmq/RabbitFlux.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/RabbitFlux.java
+++ b/src/main/java/reactor/rabbitmq/RabbitFlux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/RabbitFluxException.java
+++ b/src/main/java/reactor/rabbitmq/RabbitFluxException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/RabbitFluxException.java
+++ b/src/main/java/reactor/rabbitmq/RabbitFluxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/RabbitFluxRetryTimeoutException.java
+++ b/src/main/java/reactor/rabbitmq/RabbitFluxRetryTimeoutException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/Receiver.java
+++ b/src/main/java/reactor/rabbitmq/Receiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/Receiver.java
+++ b/src/main/java/reactor/rabbitmq/Receiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ReceiverOptions.java
+++ b/src/main/java/reactor/rabbitmq/ReceiverOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ReceiverOptions.java
+++ b/src/main/java/reactor/rabbitmq/ReceiverOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ResourceManagementOptions.java
+++ b/src/main/java/reactor/rabbitmq/ResourceManagementOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ResourceManagementOptions.java
+++ b/src/main/java/reactor/rabbitmq/ResourceManagementOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/ResourcesSpecification.java
+++ b/src/main/java/reactor/rabbitmq/ResourcesSpecification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/ResourcesSpecification.java
+++ b/src/main/java/reactor/rabbitmq/ResourcesSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/RpcClient.java
+++ b/src/main/java/reactor/rabbitmq/RpcClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/RpcClient.java
+++ b/src/main/java/reactor/rabbitmq/RpcClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/SendOptions.java
+++ b/src/main/java/reactor/rabbitmq/SendOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/SendOptions.java
+++ b/src/main/java/reactor/rabbitmq/SendOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/Sender.java
+++ b/src/main/java/reactor/rabbitmq/Sender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/Sender.java
+++ b/src/main/java/reactor/rabbitmq/Sender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/SenderOptions.java
+++ b/src/main/java/reactor/rabbitmq/SenderOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/SenderOptions.java
+++ b/src/main/java/reactor/rabbitmq/SenderOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/SubscriberState.java
+++ b/src/main/java/reactor/rabbitmq/SubscriberState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/SubscriberState.java
+++ b/src/main/java/reactor/rabbitmq/SubscriberState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/rabbitmq/Utils.java
+++ b/src/main/java/reactor/rabbitmq/Utils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/rabbitmq/Utils.java
+++ b/src/main/java/reactor/rabbitmq/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/ConnectionRecoveryTests.java
+++ b/src/test/java/reactor/rabbitmq/ConnectionRecoveryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/ConnectionRecoveryTests.java
+++ b/src/test/java/reactor/rabbitmq/ConnectionRecoveryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/ExceptionHandlersTests.java
+++ b/src/test/java/reactor/rabbitmq/ExceptionHandlersTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/ExceptionHandlersTests.java
+++ b/src/test/java/reactor/rabbitmq/ExceptionHandlersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware, Inc. or its affiliates.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/Host.java
+++ b/src/test/java/reactor/rabbitmq/Host.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/Host.java
+++ b/src/test/java/reactor/rabbitmq/Host.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/LazyChannelPoolTests.java
+++ b/src/test/java/reactor/rabbitmq/LazyChannelPoolTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/LazyChannelPoolTests.java
+++ b/src/test/java/reactor/rabbitmq/LazyChannelPoolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/QueueSpecificationTest.java
+++ b/src/test/java/reactor/rabbitmq/QueueSpecificationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/QueueSpecificationTest.java
+++ b/src/test/java/reactor/rabbitmq/QueueSpecificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
+++ b/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
+++ b/src/test/java/reactor/rabbitmq/RabbitFluxTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/ReceiverTests.java
+++ b/src/test/java/reactor/rabbitmq/ReceiverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/ReceiverTests.java
+++ b/src/test/java/reactor/rabbitmq/ReceiverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/RequestReplyTests.java
+++ b/src/test/java/reactor/rabbitmq/RequestReplyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/RequestReplyTests.java
+++ b/src/test/java/reactor/rabbitmq/RequestReplyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/SenderTests.java
+++ b/src/test/java/reactor/rabbitmq/SenderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/SenderTests.java
+++ b/src/test/java/reactor/rabbitmq/SenderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/UtilsTest.java
+++ b/src/test/java/reactor/rabbitmq/UtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/UtilsTest.java
+++ b/src/test/java/reactor/rabbitmq/UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/docs/AdvancedFeatures.java
+++ b/src/test/java/reactor/rabbitmq/docs/AdvancedFeatures.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/docs/AdvancedFeatures.java
+++ b/src/test/java/reactor/rabbitmq/docs/AdvancedFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/docs/ApiGuideReceiver.java
+++ b/src/test/java/reactor/rabbitmq/docs/ApiGuideReceiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/docs/ApiGuideReceiver.java
+++ b/src/test/java/reactor/rabbitmq/docs/ApiGuideReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/rabbitmq/docs/ApiGuideSender.java
+++ b/src/test/java/reactor/rabbitmq/docs/ApiGuideSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/rabbitmq/docs/ApiGuideSender.java
+++ b/src/test/java/reactor/rabbitmq/docs/ApiGuideSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
 - copyright header to VMware instead of Pivotal
 - update the README link
 - in copyright headers, have date range harmonized on 2017-2021
 - polish copyright header: url indentation, blank line after license