### PR TITLE
Make core and rabbit API dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ configure(allprojects) { project ->
 
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
-	apply plugin: 'java'
+	apply plugin: 'java-library'
 	apply from: "${rootDir}/gradle/setup.gradle"
 
 	sourceCompatibility = targetCompatibility = 1.8
@@ -90,8 +90,8 @@ configure(allprojects) { project ->
 	]
 
 	dependencies {
-		implementation libs.reactor.core
-		implementation libs.rabbitmq.javaClient
+		api libs.reactor.core
+		api libs.rabbitmq.javaClient
 
 		// JSR-305 annotations
 		compileOnly libs.jsr305


### PR DESCRIPTION
This would otherwise result in both theses dependencies to be set as
`runtime` scope in Maven pom. With the `java-library` plugin and the
`api` dependency style, we correctly get a `compile` scope.
