### PR TITLE
Update rabbitmq java client in  libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Baselines, should be updated on every release
 reactorCore = "3.4.29-SNAPSHOT"
-rabbitMq = "5.14.2"
+rabbitMq = "5.21.0"
 
 # Other shared versions
 asciidoctor = "3.3.2"


### PR DESCRIPTION
Update rabbitmq java client to latest (5.21.0) in  libs.versions.toml.
This includes a fix in TLS1.2 handshake.